### PR TITLE
Ie11 strangeness

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -43,7 +43,7 @@ function literalToSQL(literal) {
     else if (type === 'null') value = 'NULL';
     else if (type === 'star') value = '*';
     else if (type === 'param') value = ':' + value;
-    else if (['time', 'date', 'timestamp'].includes(type)) value = `${type.toUpperCase()} '${value}'`;
+    else if (type === 'time' || type === 'date' || type === 'timestamp') value = type.toUpperCase() + ' \'' + value + '\'';
     
     return !literal.parentheses ? value : '(' + value + ')';
 }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -42,9 +42,9 @@ function literalToSQL(literal) {
     else if (type === 'bool') value = value ? 'TRUE' : 'FALSE';
     else if (type === 'null') value = 'NULL';
     else if (type === 'star') value = '*';
-    else if (['time', 'date', 'timestamp'].includes(type)) value = `${type.toUpperCase()} '${value}'`;
     else if (type === 'param') value = ':' + value;
-
+    else if (['time', 'date', 'timestamp'].includes(type)) value = `${type.toUpperCase()} '${value}'`;
+    
     return !literal.parentheses ? value : '(' + value + ')';
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flora-sql-parser",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/pegjs-parser.js
+++ b/pegjs-parser.js
@@ -4097,7 +4097,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    s1 = peg$parseKW_BETWEEN();
+    s1 = peg$parsebetween_or_not_between_op();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
@@ -4141,6 +4141,43 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parsebetween_or_not_between_op() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$currPos;
+    s2 = peg$parseKW_NOT();
+    if (s2 !== peg$FAILED) {
+      s3 = peg$parse__();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parseKW_BETWEEN();
+        if (s4 !== peg$FAILED) {
+          s2 = [s2, s3, s4];
+          s1 = s2;
+        } else {
+          peg$currPos = s1;
+          s1 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s1;
+        s1 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s1;
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c50(s1);
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseKW_BETWEEN();
     }
 
     return s0;


### PR DESCRIPTION
Tracked down the problems with params in query builder in IE11 (https://jira.atl.workiva.net/browse/CEREBRAL-441, https://jira.atl.workiva.net/browse/CEREBRAL-444) to this line in lib/sql.js, probably because it uses unsupported functions. Changed to use vanilla js.